### PR TITLE
Improve module path parsing

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -313,12 +313,35 @@ impl Parser {
                         } else if next_mod_path2.exists() {
                             self.parse_mod(pkg, next_mod_path2.as_path())?;
                         } else {
+                            // Last chance to find a module path
+                            let mut path_attr_found = false;
+                            for attr in &item.attrs {
+                                if attr.is_sugared_doc {
+                                    continue;
+                                }
+
+                                match attr.interpret_meta() {
+                                    Some(syn::Meta::NameValue(syn::MetaNameValue { ident, lit, ..})) => {
+                                        match (ident.as_ref(), lit) {
+                                            ("path", syn::Lit::Str(ref path)) => {
+                                                path_attr_found = true;
+                                                self.parse_mod(pkg, &mod_dir.join(path.value()))?;
+                                            }
+                                            _ => (),
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+
                             // This should be an error, but it's common enough to
                             // just elicit a warning
-                            warn!(
-                                "Parsing crate `{}`: can't find mod {}`.",
-                                pkg.name, next_mod_name
-                            );
+                            if !path_attr_found {
+                                warn!(
+                                    "Parsing crate `{}`: can't find mod {}`.",
+                                    pkg.name, next_mod_name
+                                );
+                            }
                         }
                     }
 

--- a/tests/expectations/mod_path.c
+++ b/tests/expectations/mod_path.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define EXPORT_ME_TOO 42
+
+typedef struct {
+  uint64_t val;
+} ExportMe;
+
+void export_me(ExportMe *val);

--- a/tests/expectations/mod_path.cpp
+++ b/tests/expectations/mod_path.cpp
@@ -1,0 +1,14 @@
+#include <cstdint>
+#include <cstdlib>
+
+static const uint8_t EXPORT_ME_TOO = 42;
+
+struct ExportMe {
+  uint64_t val;
+};
+
+extern "C" {
+
+void export_me(ExportMe *val);
+
+} // extern "C"

--- a/tests/rust/mod_path/Cargo.lock
+++ b/tests/rust/mod_path/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "mod_path"
+version = "0.1.0"
+

--- a/tests/rust/mod_path/Cargo.toml
+++ b/tests/rust/mod_path/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mod_path"
+version = "0.1.0"
+authors = ["cbindgen"]
+
+[lib]
+name = "mod_path"
+crate-type = ["lib", "dylib"]

--- a/tests/rust/mod_path/cbindgen.toml
+++ b/tests/rust/mod_path/cbindgen.toml
@@ -1,0 +1,2 @@
+[parse]
+parse_deps = false

--- a/tests/rust/mod_path/src/lib.rs
+++ b/tests/rust/mod_path/src/lib.rs
@@ -1,0 +1,4 @@
+#[path = "other.rs"]
+mod inner;
+
+pub use inner::*;

--- a/tests/rust/mod_path/src/other.rs
+++ b/tests/rust/mod_path/src/other.rs
@@ -1,0 +1,14 @@
+#[repr(C)]
+pub struct ExportMe {
+    val: u64
+}
+
+#[repr(C)]
+pub struct DoNotExportMe {
+    val: u64
+}
+
+pub const EXPORT_ME_TOO: u8 = 0x2a;
+
+#[no_mangle]
+pub unsafe extern "C" fn export_me(val: *mut ExportMe) { }


### PR DESCRIPTION
If a module has a path attribute use this as the module path to parse.

Should fix: https://github.com/redox-os/relibc/pull/60#discussion_r173628588